### PR TITLE
added missed "options" argument for AwsAdapterDefinitionBuilder

### DIFF
--- a/src/Adapter/Builder/AwsAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AwsAdapterDefinitionBuilder.php
@@ -45,6 +45,9 @@ class AwsAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
         $resolver->setDefault('prefix', '');
         $resolver->setAllowedTypes('prefix', 'string');
+
+        $resolver->setDefault('options', []);
+        $resolver->setAllowedTypes('options', 'array');
     }
 
     protected function configureDefinition(Definition $definition, array $options)
@@ -53,5 +56,6 @@ class AwsAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $definition->setArgument(0, new Reference($options['client']));
         $definition->setArgument(1, $options['bucket']);
         $definition->setArgument(2, $options['prefix']);
+        $definition->setArgument(3, $options['options']);
     }
 }


### PR DESCRIPTION
League\Flysystem\AwsS3v3\AwsS3Adapter supports 4th argument named "options", but it's missed in this package.

With the proposed changes I can now describe AWS storage as the following:

```
flysystem:
    storages:
        aws.storage:
            adapter: 'aws'
            options:
                client: 'aws-client-id'
                bucket: 'bucket-name'
                options:
                    ACL: 'public-read'
```

You can see the `ACL: 'public-read'` which is now passed to AwsS3Adapter

Please release new version after merge.